### PR TITLE
Hide system tags from user-facing UI

### DIFF
--- a/ui/components/lesson_browser.py
+++ b/ui/components/lesson_browser.py
@@ -105,8 +105,8 @@ def render_lesson_browser(user: UserProfile, db: Database):
 
     st.markdown("### 📚 Browse Lessons")
 
-    # Get all tags
-    all_tags = db.get_all_tags()
+    # Get only user-created tags
+    all_tags = db.get_user_tags()
 
     if not all_tags:
         st.info("No tags available. Visit the Tag Management page to create tags.")

--- a/ui/pages/lesson_packages.py
+++ b/ui/pages/lesson_packages.py
@@ -133,8 +133,8 @@ def render_export_tab(db, user):
         selected_domain = st.selectbox("Filter by Domain", ["All Domains"] + all_domains)
 
     with col2:
-        # Tag selector
-        all_tags = db.get_all_tags()
+        # Tag selector (only show user-created tags)
+        all_tags = db.get_user_tags()
         tag_names = ["All Tags"] + [tag.name for tag in all_tags]
         selected_tag = st.selectbox("Filter by Tag", tag_names)
 

--- a/ui/pages/lesson_viewer.py
+++ b/ui/pages/lesson_viewer.py
@@ -25,8 +25,8 @@ def render(user: UserProfile, db: Database):
         _render_completion_feedback(completion_summary)
         st.markdown("---")
 
-    # Tag filter section
-    all_tags = db.get_all_tags()
+    # Tag filter section (only show user-created tags)
+    all_tags = db.get_user_tags()
 
     if all_tags:
         st.markdown("#### 🏷️ Filter by Tags")
@@ -271,7 +271,7 @@ def render_domain_lessons(user: UserProfile, db: Database, domain: str):
                 if is_editing:
                     st.markdown('<div style="background-color: #f8f9fa; padding: 8px; border-radius: 5px; margin: 5px 0;">', unsafe_allow_html=True)
 
-                    all_tags = db.get_all_tags()
+                    all_tags = db.get_user_tags()  # Only show user tags for tagging lessons
                     current_tag_ids = {tag.tag_id for tag in lesson_tags}
 
                     # Current tags - compact

--- a/ui/pages/search.py
+++ b/ui/pages/search.py
@@ -72,8 +72,8 @@ def render_search_page():
         else:
             selected_completion = "All Lessons"
 
-    # Tag filter
-    available_tags = db.get_all_tags()
+    # Tag filter (only show user-created tags)
+    available_tags = db.get_user_tags()
     tag_names = ["All Tags"] + [tag.name for tag in available_tags]
     selected_tag = st.selectbox("Filter by Tag", tag_names, key="search_tag")
 

--- a/ui/pages/tag_management.py
+++ b/ui/pages/tag_management.py
@@ -21,15 +21,15 @@ def render_tag_management(db: Database):
 
     # TAB 1: View and manage existing tags
     with tab1:
-        st.subheader("All Tags")
+        st.subheader("My Tags")
 
-        tags = db.get_all_tags()
+        tags = db.get_user_tags()  # Only get user-created tags
 
         if not tags:
             st.info("No tags found. Create your first tag in the 'Create Tag' tab.")
         else:
-            # Sort tags: system tags first, then custom tags
-            sorted_tags = sorted(tags, key=lambda t: (not t.is_system, t.name))
+            # Sort tags by name
+            sorted_tags = sorted(tags, key=lambda t: t.name)
 
             # Display tags in a nice grid
             cols = st.columns(3)
@@ -83,33 +83,29 @@ def render_tag_management(db: Database):
                                 {tag.icon} {tag.name}
                             </h3>
                             <p style="margin: 5px 0; font-size: 0.9em;">{tag.description or 'No description'}</p>
-                            <p style="margin: 5px 0; font-size: 0.8em; color: #666;">
-                                {'🔒 System Tag' if tag.is_system else '✏️ Custom Tag'}
-                            </p>
                         </div>
                         """, unsafe_allow_html=True)
 
-                        # Functional buttons for custom tags
-                        if not tag.is_system:
-                            col_a, col_b = st.columns(2)
-                            with col_a:
-                                if st.button(f"✏️ Edit", key=f"edit_{tag.tag_id}", use_container_width=True):
-                                    st.session_state[f'editing_tag'] = tag.tag_id
-                                    st.rerun()
+                        # Functional buttons (all tags shown are user tags, so all can be edited/deleted)
+                        col_a, col_b = st.columns(2)
+                        with col_a:
+                            if st.button(f"✏️ Edit", key=f"edit_{tag.tag_id}", use_container_width=True):
+                                st.session_state[f'editing_tag'] = tag.tag_id
+                                st.rerun()
 
-                            with col_b:
-                                if st.button(f"🗑️ Delete", key=f"del_{tag.tag_id}", use_container_width=True, type="secondary"):
-                                    if st.session_state.get(f'confirm_delete_{tag.tag_id}'):
-                                        try:
-                                            db.delete_tag(tag.tag_id)
-                                            st.success(f"Deleted tag: {tag.name}")
-                                            st.rerun()
-                                        except ValueError as e:
-                                            st.error(str(e))
-                                    else:
-                                        st.session_state[f'confirm_delete_{tag.tag_id}'] = True
-                                        st.warning("Click again to confirm deletion")
+                        with col_b:
+                            if st.button(f"🗑️ Delete", key=f"del_{tag.tag_id}", use_container_width=True, type="secondary"):
+                                if st.session_state.get(f'confirm_delete_{tag.tag_id}'):
+                                    try:
+                                        db.delete_tag(tag.tag_id)
+                                        st.success(f"Deleted tag: {tag.name}")
                                         st.rerun()
+                                    except ValueError as e:
+                                        st.error(str(e))
+                                else:
+                                    st.session_state[f'confirm_delete_{tag.tag_id}'] = True
+                                    st.warning("Click again to confirm deletion")
+                                    st.rerun()
 
     # TAB 2: Create new tag
     with tab2:

--- a/utils/database.py
+++ b/utils/database.py
@@ -884,9 +884,29 @@ class Database:
         )
 
     def get_all_tags(self) -> List[Tag]:
-        """Get all tags"""
+        """Get all tags (including system tags)"""
         cursor = self.conn.cursor()
         cursor.execute("SELECT * FROM tags ORDER BY name")
+
+        tags = []
+        for row in cursor.fetchall():
+            tags.append(Tag(
+                tag_id=row['id'],
+                name=row['name'],
+                category=row['category'],
+                color=row['color'],
+                icon=row['icon'],
+                description=row['description'],
+                created_at=datetime.fromisoformat(row['created_at']),
+                is_system=bool(row['is_system'])
+            ))
+
+        return tags
+
+    def get_user_tags(self) -> List[Tag]:
+        """Get only user-created tags (excludes system tags)"""
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT * FROM tags WHERE is_system = 0 ORDER BY name")
 
         tags = []
         for row in cursor.fetchall():


### PR DESCRIPTION
## Summary
Fixed issue where system tags (Career Path, Course, Package tags) were visible to users, causing confusion. Users should only see and manage their own custom tags.

## Problem
- System tags were appearing in tag management page
- System tags showed up in search/filter dropdowns
- Users could see but not delete/edit system tags
- This created confusion about what tags users could actually manage

## Root Cause
All UI pages were using `get_all_tags()` which returns both system and user-created tags without distinction in the UI.

## Solution

### 1. Database Layer
- **Added `get_user_tags()` method**: New method that filters out system tags (WHERE is_system = 0)
- **Kept `get_all_tags()` intact**: System processes can still access all tags for auto-tagging, etc.

### 2. UI Updates
Updated all user-facing pages to use `get_user_tags()` instead of `get_all_tags()`:

- **Tag Management** ([tag_management.py](ui/pages/tag_management.py)): Only shows user-created tags
- **Search** ([search.py](ui/pages/search.py)): Filter dropdowns only show user tags
- **Lesson Viewer** ([lesson_viewer.py](ui/pages/lesson_viewer.py)): Tag filters and lesson tagging use user tags
- **Lesson Packages** ([lesson_packages.py](ui/pages/lesson_packages.py)): Package filtering uses user tags
- **Lesson Browser** ([lesson_browser.py](ui/components/lesson_browser.py)): Browse filters use user tags

### 3. UI Simplification
- Removed "🔒 System Tag" / "✏️ Custom Tag" indicators (all shown tags are now custom)
- Removed conditional edit/delete button logic (all shown tags are editable)

## Expected Behavior

### After Fix:
- ✅ **Tag Management page**: Only displays user-created tags
- ✅ **Search/Filter dropdowns**: Only user tags available for filtering
- ✅ **Lesson tagging**: Users can only tag lessons with their own tags
- ✅ **System tags**: Still exist in database for system use (auto-tagging from lesson_ideas.csv)
- ✅ **No confusion**: Users only see what they can actually manage

### System Tags Still Work:
- System tags remain in the database
- Lessons keep their system tag associations
- Auto-tagging scripts still work with system tags
- Only the UI hides them from normal users

## Testing on VM

```bash
cd /path/to/cyberlearn
git fetch origin
git checkout hide-system-tags
git pull origin hide-system-tags
streamlit run app.py
```

### Test Steps:
1. **Tag Management Page** (🏷️ Manage Tags):
   - Should only show user-created tags
   - Should NOT show Career Path, Course, or Package tags
   - All visible tags should be editable/deletable

2. **Search Page** (🔍 Search Lessons):
   - "Filter by Tag" dropdown should only show user tags
   - System tags should not appear

3. **My Learning Page** (📚 My Learning):
   - Tag filter multiselect should only show user tags
   - Lesson tagging should only offer user tags

4. **Create a test tag**:
   - Go to Tag Management
   - Create a new tag (e.g., "My Test Tag")
   - Verify it appears in all filter dropdowns

## Files Changed
- [utils/database.py](utils/database.py) - Added `get_user_tags()` method
- [ui/pages/tag_management.py](ui/pages/tag_management.py) - Show only user tags
- [ui/pages/search.py](ui/pages/search.py) - Filter with user tags
- [ui/pages/lesson_viewer.py](ui/pages/lesson_viewer.py) - User tags in filters
- [ui/pages/lesson_packages.py](ui/pages/lesson_packages.py) - User tags for packages
- [ui/components/lesson_browser.py](ui/components/lesson_browser.py) - Browse with user tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)