### PR TITLE
Fix: Page refresh shows wrong page (always shows last lesson)

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,8 +95,9 @@ def sync_url_to_session_state():
     if "page" in params:
         st.session_state.current_page = params["page"]
 
-    # If lesson_id is in URL, load that lesson
-    if "lesson_id" in params:
+    # If lesson_id is in URL AND page is "lesson", load that lesson
+    # This prevents lesson from loading when on other pages
+    if "lesson_id" in params and params.get("page") == "lesson":
         lesson_id = params["lesson_id"]
         if st.session_state.get("db"):
             lesson = st.session_state.db.get_lesson(lesson_id)
@@ -117,7 +118,8 @@ def sync_session_state_to_url():
     if st.session_state.current_page == "lesson" and st.session_state.get("current_lesson"):
         params["lesson_id"] = str(st.session_state.current_lesson.lesson_id)
 
-    # Update URL without triggering rerun
+    # Clear and set URL parameters (prevents old params from persisting)
+    st.query_params.clear()
     st.query_params.update(params)
 
     # Update last known URL to prevent re-syncing on next render


### PR DESCRIPTION
## Issue
After viewing a lesson and navigating to another page (search, dashboard, etc.), refreshing the page would incorrectly show the last viewed lesson instead of staying on the current page.

**Steps to reproduce:**
1. View lesson 01
2. Navigate to search page
3. Refresh the page
4. **Bug**: Page shows lesson 01 instead of staying on search

## Root Cause
Two issues:
1. `sync_url_to_session_state()` was loading lesson from URL even when `page` parameter was not "lesson"
2. `sync_session_state_to_url()` was not clearing old URL parameters, so `lesson_id` persisted across page navigation

## Solution
1. **Only load lesson if page is "lesson"**: Added check `params.get("page") == "lesson"` before loading lesson from URL
2. **Clear stale URL params**: Added `st.query_params.clear()` before setting new params to prevent old parameters from persisting

## Changes
- [app.py:100](app.py#L100) - Added condition to only load lesson when page param is "lesson"
- [app.py:122](app.py#L122) - Clear URL params before updating to remove stale params

## Testing
Test on VM:
```bash
cd /home/cyberlearn/cyberlearn
git fetch
git checkout fix-page-refresh-navigation
git pull
streamlit run app.py
```

**Test scenarios:**
1. View a lesson → Navigate to search → Refresh → Should stay on search
2. View a lesson → Navigate to dashboard → Refresh → Should stay on dashboard
3. View a lesson → Refresh → Should stay on the same lesson (existing behavior preserved)
4. Use browser back/forward → Should navigate correctly